### PR TITLE
Remaining animation crud

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'corretto'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         with:

--- a/Readme.md
+++ b/Readme.md
@@ -34,8 +34,14 @@ To get the project up and running:
 git clone git@github.com:chris-schmitz/matrix-animator-api-2.git
 cd matrix-animator-api-2
 
+# To list all of the gradle tasks, including the ones custom to this project:
+./gradlew tasks --all
+
 # To launch a local instance of the project (note this will launch detached):
 ./gradlew dockerComposeUp
+
+# To rebuild the jar and relaunch an already running list of services:
+./gradlew dockerComposeReload
 
 # To stop the local instance of the project:
 ./gradlew dockerComposeDown

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,14 +72,20 @@ tasks {
         }
     }
     val dockerComposeDown by creating(Task::class) {
-        description = "Pulls a running detached docker servies down."
+        description = "Pulls a running detached docker services down."
         doLast {
             project.exec {
                 commandLine("sh", "-c", "docker-compose down")
             }
         }
     }
+    val dockerComposeReload by creating(Task::class) {
+        description = "Reload the docker services if they're already running. Includes jar rebuild."
+        dependsOn(dockerComposeDown)
+        dependsOn(dockerComposeUp)
+    }
 }
+tasks.getByName("dockerComposeUp").mustRunAfter(tasks.getByName("dockerComposeDown"))
 
 // !--------Build Utilities---------! //
 // * I tried to pull these out to a class, but when I did intellij was _not happy_ about it.

--- a/matrix-animator-api.http
+++ b/matrix-animator-api.http
@@ -10,6 +10,6 @@ Content-Type: application/json
   "frames": []
 }
 
-#### Get all animations
-#GET http://localhost:8080/rest/animations/
-#
+### Get all animations
+@id =1
+GET http://localhost:8080/rest/animations/{{id}}

--- a/matrix-animator-api.http
+++ b/matrix-animator-api.http
@@ -10,6 +10,9 @@ Content-Type: application/json
   "frames": []
 }
 
-### Get all animations
+### Get an animation by id
 @id =1
 GET http://localhost:8080/rest/animations/{{id}}
+
+### Get all animations
+GET http://localhost:8080/rest/animations

--- a/matrix-animator-api.http
+++ b/matrix-animator-api.http
@@ -16,3 +16,16 @@ GET http://localhost:8080/rest/animations/{{id}}
 
 ### Get all animations
 GET http://localhost:8080/rest/animations
+
+### Update existing animation
+PUT http://localhost:8080/rest/animations
+Content-Type: application/json
+
+{
+  "title": "Updated animation",
+  "frames": [],
+  "id": 34,
+  "height": 1,
+  "width": 2,
+  "speed": 3
+}

--- a/matrix-animator-api.http
+++ b/matrix-animator-api.http
@@ -1,6 +1,3 @@
-### Test
-GET http://localhost:8080/rest/animations/test
-
 ### save an animation
 POST http://localhost:8080/rest/animations
 Content-Type: application/json
@@ -11,7 +8,9 @@ Content-Type: application/json
 }
 
 ### Get an animation by id
-@id =1
+< {%
+    request.variables.set("id", "35")
+%}
 GET http://localhost:8080/rest/animations/{{id}}
 
 ### Get all animations
@@ -29,3 +28,9 @@ Content-Type: application/json
   "width": 2,
   "speed": 3
 }
+
+### Delete a specific animation
+< {%
+    request.variables.set("id", "38")
+%}
+DELETE http://localhost:8080/rest/animations/{{id}}

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
@@ -1,6 +1,7 @@
 package com.lightinspiration.matrixanimatorapi.controllers
 
 import com.lightinspiration.matrixanimatorapi.domain.Animation
+import com.lightinspiration.matrixanimatorapi.domain.AnimationMeta
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -15,6 +16,11 @@ class AnimationController(
     @GetMapping("/{id}")
     fun getAnimation(@PathVariable("id") id: Int): Animation {
         return animationService.getAnimation(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+    }
+
+    @GetMapping
+    fun getAnimationList(): List<AnimationMeta> {
+        return animationService.getAnimationList()
     }
 
     @PostMapping

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
@@ -3,7 +3,8 @@ package com.lightinspiration.matrixanimatorapi.controllers
 import com.lightinspiration.matrixanimatorapi.domain.Animation
 import com.lightinspiration.matrixanimatorapi.domain.AnimationMeta
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
-import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 
@@ -15,7 +16,7 @@ class AnimationController(
 
     @GetMapping("/{id}")
     fun getAnimation(@PathVariable("id") id: Int): Animation {
-        return animationService.getAnimation(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        return animationService.getAnimation(id) ?: throw ResponseStatusException(NOT_FOUND)
     }
 
     @GetMapping
@@ -26,5 +27,14 @@ class AnimationController(
     @PostMapping
     fun saveAnimation(@RequestBody animation: Animation) {
         animationService.saveAnimation(animation)
+    }
+
+    @PutMapping
+    fun updateAnimation(@RequestBody animation: Animation) {
+        return if (animation.id != null)
+            animationService.updateAnimation(animation.id, animation)
+        else
+            throw ResponseStatusException(UNPROCESSABLE_ENTITY, "We can't update an animation without it's ID.")
+
     }
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
@@ -37,4 +37,9 @@ class AnimationController(
             throw ResponseStatusException(UNPROCESSABLE_ENTITY, "We can't update an animation without it's ID.")
 
     }
+
+    @DeleteMapping("/{id}")
+    fun deleteAnimation(@PathVariable("id") id: Int) {
+        animationService.deleteAnimation(id)
+    }
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
@@ -2,7 +2,9 @@ package com.lightinspiration.matrixanimatorapi.controllers
 
 import com.lightinspiration.matrixanimatorapi.domain.Animation
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 @RequestMapping("/rest/animations")
@@ -10,11 +12,9 @@ class AnimationController(
     private val animationService: AnimationService,
 ) {
 
-    // TODO: rip out after adding a legit get call
-    // ! don't forget to pull it out of the http client.
-    @GetMapping("/test")
-    fun test(): String {
-        return "worked again!! :O :O :O :nice:"
+    @GetMapping("/{id}")
+    fun getAnimation(@PathVariable("id") id: Int): Animation {
+        return animationService.getAnimation(id) ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
     }
 
     @PostMapping

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/domain/Animation.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/domain/Animation.kt
@@ -1,5 +1,6 @@
 package com.lightinspiration.matrixanimatorapi.domain
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 
 data class Animation(
@@ -15,7 +16,7 @@ data class Animation(
         return ObjectMapper().writeValueAsString(this)
     }
 
-    // TODO: this is kind of ok, but should we solve this via inheritance??? Does it matter?
+    @JsonIgnore
     fun getMeta(): AnimationMeta {
         return AnimationMeta(this.id, this.title)
     }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/domain/Animation.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/domain/Animation.kt
@@ -14,4 +14,11 @@ data class Animation(
     fun toJson(): String {
         return ObjectMapper().writeValueAsString(this)
     }
+
+    // TODO: this is kind of ok, but should we solve this via inheritance??? Does it matter?
+    fun getMeta(): AnimationMeta {
+        return AnimationMeta(this.id, this.title)
+    }
 }
+
+data class AnimationMeta(val id: Int? = null, val title: String)

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
@@ -1,10 +1,13 @@
 package com.lightinspiration.matrixanimatorapi.repositories
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.lightinspiration.matrixanimatorapi.domain.Animation
+import com.lightinspiration.matrixanimatorapi.domain.Frame
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
+import java.sql.ResultSet
 
 @Repository
 class AnimationRepository(
@@ -28,5 +31,34 @@ class AnimationRepository(
                 .addValue("speed", animation.speed)
         )
     }
+
+    fun getAnimation(id: Int): Animation? {
+        return template.query(
+            """
+            SELECT 
+                id, title, frames, user_id, height, width, speed
+            FROM 
+                matrix_animator.animations
+            WHERE 
+                id = :id
+        """,
+            MapSqlParameterSource().addValue("id", id),
+            animationRowMapper
+        )
+            .firstOrNull()
+    }
+
+    private val animationRowMapper: (ResultSet, Int) -> Animation =
+        { resultSet, _ ->
+            Animation(
+                resultSet.getString("title"),
+                resultSet.getInt("user_id"),
+                resultSet.getInt("height"),
+                resultSet.getInt("width"),
+                resultSet.getInt("speed"),
+                objectMapper.readValue(resultSet.getString("frames"), object : TypeReference<List<Frame>>() {}),
+                resultSet.getInt("id")
+            )
+        }
 
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
@@ -57,6 +57,16 @@ class AnimationRepository(
         )
     }
 
+    fun deleteAnimation(id: Int): Int {
+        return template.update(
+            """
+                DELETE FROM matrix_animator.animations
+                WHERE id = :id
+            """,
+            MapSqlParameterSource().addValue("id", id)
+        )
+    }
+
     private fun mapAnimationToParameters(animation: Animation) =
         MapSqlParameterSource()
             .addValue("title", animation.title)

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
@@ -6,6 +6,7 @@ import com.lightinspiration.matrixanimatorapi.domain.Animation
 import com.lightinspiration.matrixanimatorapi.domain.Frame
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.support.GeneratedKeyHolder
 import org.springframework.stereotype.Repository
 import java.sql.ResultSet
 
@@ -31,7 +32,8 @@ class AnimationRepository(
         return template.query(ANIMATION_SELECT_QUERY, animationRowMapper)
     }
 
-    fun saveAnimation(animation: Animation) {
+    fun saveAnimation(animation: Animation): Int {
+        val keyholder = GeneratedKeyHolder()
         template.update(
             """
             INSERT INTO matrix_animator.animations
@@ -39,8 +41,10 @@ class AnimationRepository(
             VALUES
             (:title, :frames::jsonb, :userId, :height, :width, :speed)
             """,
-            mapAnimationToParameters(animation)
+            mapAnimationToParameters(animation),
+            keyholder
         )
+        return keyholder.keys?.get("id") as Int
     }
 
     fun updateAnimation(id: Int, animation: Animation) {

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
@@ -35,17 +35,17 @@ class AnimationRepository(
     fun getAnimation(id: Int): Animation? {
         return template.query(
             """
-            SELECT 
-                id, title, frames, user_id, height, width, speed
-            FROM 
-                matrix_animator.animations
-            WHERE 
-                id = :id
-        """,
+                $ANIMATION_SELECT_QUERY
+                WHERE id = :id
+            """,
             MapSqlParameterSource().addValue("id", id),
             animationRowMapper
         )
             .firstOrNull()
+    }
+
+    fun getAnimations(): List<Animation> {
+        return template.query(ANIMATION_SELECT_QUERY, animationRowMapper)
     }
 
     private val animationRowMapper: (ResultSet, Int) -> Animation =
@@ -61,4 +61,12 @@ class AnimationRepository(
             )
         }
 
+    companion object {
+        private const val ANIMATION_SELECT_QUERY = """
+            SELECT 
+                id, title, frames, user_id, height, width, speed
+            FROM 
+                matrix_animator.animations
+        """
+    }
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
@@ -10,7 +10,7 @@ class AnimationService(
     val animationRepository: AnimationRepository
 ) {
     fun saveAnimation(animation: Animation) {
-        animationRepository.save(animation)
+        animationRepository.saveAnimation(animation)
     }
 
     fun getAnimation(id: Int): Animation? {
@@ -21,6 +21,10 @@ class AnimationService(
         return animationRepository
             .getAnimations()
             .map { it.getMeta() }
+    }
+
+    fun updateAnimation(id: Int, animation: Animation) {
+        animationRepository.updateAnimation(id, animation)
     }
 
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
@@ -1,6 +1,7 @@
 package com.lightinspiration.matrixanimatorapi.services
 
 import com.lightinspiration.matrixanimatorapi.domain.Animation
+import com.lightinspiration.matrixanimatorapi.domain.AnimationMeta
 import com.lightinspiration.matrixanimatorapi.repositories.AnimationRepository
 import org.springframework.stereotype.Service
 
@@ -14,6 +15,12 @@ class AnimationService(
 
     fun getAnimation(id: Int): Animation? {
         return animationRepository.getAnimation(id)
+    }
+
+    fun getAnimationList(): List<AnimationMeta> {
+        return animationRepository
+            .getAnimations()
+            .map { it.getMeta() }
     }
 
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
@@ -27,4 +27,8 @@ class AnimationService(
         animationRepository.updateAnimation(id, animation)
     }
 
+    fun deleteAnimation(id: Int) {
+        animationRepository.deleteAnimation(id)
+    }
+
 }

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
@@ -12,4 +12,8 @@ class AnimationService(
         animationRepository.save(animation)
     }
 
+    fun getAnimation(id: Int): Animation? {
+        return animationRepository.getAnimation(id)
+    }
+
 }

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/configuration/TestDataSourceConfiguration.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/configuration/TestDataSourceConfiguration.kt
@@ -1,12 +1,5 @@
 package com.lightinspiration.matrixanimatorapi.configuration
 
-import liquibase.Contexts
-import liquibase.LabelExpression
-import liquibase.Liquibase
-import liquibase.Scope
-import liquibase.database.DatabaseFactory
-import liquibase.database.jvm.JdbcConnection
-import liquibase.resource.DirectoryResourceAccessor
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.jdbc.DataSourceBuilder
 import org.springframework.context.annotation.Bean
@@ -14,7 +7,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.testcontainers.containers.PostgreSQLContainer
-import java.io.File
 import javax.sql.DataSource
 
 @Configuration("test-datasource-configuration")
@@ -62,36 +54,6 @@ class TestDataSourceConfiguration {
                 }
                 .build()
         }
-
-        // * keeping this around for now. I have a feeling there's a chance this may be needed once the
-        // * db creds for prod and test are different, but really that _should_ be solve-able via test properties.
-        fun buildSchema(dataSource: DataSource) {
-            Scope.child(
-                emptyMap()
-            ) { ->
-                // TODO: the path should prob be abstracted and passed in as a property
-                val changeLog = File("src/main/resources/db/changelog/db.changelog-master.yaml")
-                val liquibase = Liquibase(
-                    changeLog.name,
-                    DirectoryResourceAccessor(changeLog.parentFile),
-                    DatabaseFactory.getInstance()
-                        .findCorrectDatabaseImplementation(JdbcConnection(dataSource.connection))
-                )
-                liquibase.update(Contexts(), LabelExpression())
-                // * From what I'm reading this _should_ be the non-deprecated approach to starting and running liquibase,
-                // * but it doesn't work and I'm tired of fiddling with it :|
-                //val database =
-                //    DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(dataSource.connection))
-                //CommandScope(UpdateCommandStep.COMMAND_NAME.first())
-                //    .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database)
-                //    .addArgumentValue(
-                //        UpdateCommandStep.CHANGELOG_FILE_ARG,
-                //        "src/test/resources/db/changelog/db.changelog-master.yaml"
-                //    )
-                //    .execute()
-            }
-        }
-
     }
 }
 

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationsControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationsControllerIntegrationTest.kt
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.jdbc.support.GeneratedKeyHolder
 import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
@@ -22,34 +25,75 @@ class AnimationsControllerIntegrationTest {
     private lateinit var jdbcTemplate: JdbcTemplate
 
     @Autowired
+    private lateinit var namedParameterJdbcTemplate: NamedParameterJdbcTemplate
+
+    @Autowired
     private lateinit var objectMapper: ObjectMapper
 
 
     @Test
     fun `saveAnimation - can save an animation`() {
-        val animation = Animation(
-            "Test animation",
-            1,
-            8,
-            8,
-            1,
-            listOf(Frame(0, listOf(0xFF00FF, 0x00FF00, 0xFF00FF)))
-        )
+        val animation = buildAnimationInstance()
 
         animationController.saveAnimation(animation)
 
-        val actual =
-            jdbcTemplate.queryForObject("""SELECT * FROM matrix_animator.animations LIMIT 1""") { resultSet, _ ->
-                val a = Animation(
-                    resultSet.getString("title"),
-                    resultSet.getInt("user_id"),
-                    resultSet.getInt("height"),
-                    resultSet.getInt("width"),
-                    resultSet.getInt("speed"),
-                    objectMapper.readValue(resultSet.getString("frames"), object : TypeReference<List<Frame>>() {})
-                )
-                a
-            }
-        assertEquals(animation, actual)
+        assertEquals(animation, getAnimationFromDatabase())
     }
+
+    @Test
+    fun `getAnimation - if record exists - can get animation`() {
+        val animation = buildAnimationInstance()
+        val insertedId = insertAnimationIntoDatabase(animation)
+
+        val actual = animationController.getAnimation(insertedId)
+
+        assertEquals(animation.copy(id = insertedId), actual)
+    }
+
+    private fun insertAnimationIntoDatabase(animation: Animation): Int {
+        val keyHolder = GeneratedKeyHolder()
+        val parameterMap =
+            MapSqlParameterSource()
+                .addValue("title", animation.title)
+                .addValue("frames", objectMapper.writeValueAsString(animation.frames))
+                .addValue("userId", animation.userId)
+                .addValue("height", animation.height)
+                .addValue("width", animation.width)
+                .addValue("speed", animation.speed)
+
+        namedParameterJdbcTemplate.update(
+            """
+                INSERT INTO matrix_animator.animations
+                (title, frames, user_id, height, width, speed)
+                VALUES
+                (:title, :frames::jsonb, :userId, :height, :width, :speed)
+            """,
+            parameterMap,
+            keyHolder,
+            arrayOf("id")
+        )
+        return keyHolder.keys?.get("id") as Int
+    }
+
+    private fun getAnimationFromDatabase() =
+        jdbcTemplate.queryForObject("""SELECT * FROM matrix_animator.animations LIMIT 1""") { resultSet, _ ->
+            val a = Animation(
+                resultSet.getString("title"),
+                resultSet.getInt("user_id"),
+                resultSet.getInt("height"),
+                resultSet.getInt("width"),
+                resultSet.getInt("speed"),
+                objectMapper.readValue(resultSet.getString("frames"), object : TypeReference<List<Frame>>() {})
+            )
+            a
+        }
+
+    private fun buildAnimationInstance() = Animation(
+        "Test animation",
+        1,
+        8,
+        8,
+        1,
+        listOf(Frame(0, listOf(0xFF00FF, 0x00FF00, 0xFF00FF)))
+    )
 }

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationsControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationsControllerIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.lightinspiration.matrixanimatorapi.controllers
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.lightinspiration.matrixanimatorapi.domain.Animation
+import com.lightinspiration.matrixanimatorapi.domain.AnimationMeta
 import com.lightinspiration.matrixanimatorapi.domain.Frame
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -13,6 +14,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.jdbc.support.GeneratedKeyHolder
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
 @ActiveProfiles("integration-test")
@@ -32,6 +34,7 @@ class AnimationsControllerIntegrationTest {
 
 
     @Test
+    @Transactional
     fun `saveAnimation - can save an animation`() {
         val animation = buildAnimationInstance()
 
@@ -41,6 +44,7 @@ class AnimationsControllerIntegrationTest {
     }
 
     @Test
+    @Transactional
     fun `getAnimation - if record exists - can get animation`() {
         val animation = buildAnimationInstance()
         val insertedId = insertAnimationIntoDatabase(animation)
@@ -49,6 +53,25 @@ class AnimationsControllerIntegrationTest {
 
         assertEquals(animation.copy(id = insertedId), actual)
     }
+
+    @Test
+    @Transactional
+    fun `getAnimationList - can get list of animation metadata`() {
+        val animations =
+            listOf(
+                buildAnimationInstance("animation 1"),
+                buildAnimationInstance("animation 2")
+            )
+        val expected = animations.map {
+            val id = insertAnimationIntoDatabase(it)
+            AnimationMeta(id, it.title)
+        }
+
+        val actual = animationController.getAnimationList()
+
+        assertEquals(expected, actual)
+    }
+
 
     private fun insertAnimationIntoDatabase(animation: Animation): Int {
         val keyHolder = GeneratedKeyHolder()
@@ -88,8 +111,8 @@ class AnimationsControllerIntegrationTest {
             a
         }
 
-    private fun buildAnimationInstance() = Animation(
-        "Test animation",
+    private fun buildAnimationInstance(title: String? = null) = Animation(
+        title ?: "Test animation",
         1,
         8,
         8,

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
@@ -51,25 +51,10 @@ class AnimationRepositoryTest {
     fun `saveAnimation - can save animation record successfully`() {
         val animation = buildAnimation()
 
-        //TODO: return the id and then make sure you're getting the exact record, not just whatever first one is returned
-        animationRepository.saveAnimation(animation)
+        val id = animationRepository.saveAnimation(animation)
 
-        val actual = namedParameterJdbcTemplate.query(
-            """
-            SELECT * FROM matrix_animator.animations
-        """,
-        ) { resultSet, _ ->
-            val a = Animation(
-                resultSet.getString("title"),
-                resultSet.getInt("user_id"),
-                resultSet.getInt("height"),
-                resultSet.getInt("width"),
-                resultSet.getInt("speed"),
-                objectMapper.readValue(resultSet.getString("frames"), object : TypeReference<List<Frame>>() {})
-            )
-            a
-        }
-        assertEquals(listOf(animation), actual)
+        val actual = getAnimationRecord(id)
+        assertEquals(animation.copy(id = id), actual)
     }
 
     @Test
@@ -82,8 +67,7 @@ class AnimationRepositoryTest {
 
         animationRepository.updateAnimation(id, updatedAnimation)
 
-        val actual = getAnimationRecord(id)
-        assertEquals(listOf(updatedAnimation.copy(id = id)), actual)
+        assertEquals(updatedAnimation.copy(id = id), getAnimationRecord(id))
     }
 
 
@@ -103,7 +87,7 @@ class AnimationRepositoryTest {
 
     @Test
     @Transactional
-    fun `deleteAnimation - if record doesn't exist to delete - expect exception`() {
+    fun `deleteAnimation - if record doesn't exist to delete - expect no record change`() {
         val numberOfRowsAffected = animationRepository.deleteAnimation(999)
 
         assertEquals(0, numberOfRowsAffected)

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
@@ -89,6 +89,24 @@ class AnimationRepositoryTest {
         assertEquals(null, actual)
     }
 
+    @Test
+    @Transactional
+    fun `getAnimations - if animation records exists - can get list`() {
+        val animations = listOf(
+            buildAnimation("animation 1"),
+            buildAnimation("animation 2"),
+        )
+        val expected = animations.map {
+            val id = insertAnimationRecord(it)
+            it.copy(id = id)
+        }
+
+        val actual = animationRepository.getAnimations()
+
+        assertEquals(expected, actual)
+    }
+
+
     private fun insertAnimationRecord(animation: Animation): Int {
         val keyHolder = GeneratedKeyHolder()
         val parameterMap =
@@ -115,9 +133,9 @@ class AnimationRepositoryTest {
     }
 
     companion object {
-        fun buildAnimation(id: Int? = null): Animation {
+        fun buildAnimation(title: String? = null, id: Int? = null): Animation {
             return Animation(
-                "a cool animation",
+                title ?: "a cool animation",
                 1,
                 8,
                 8,

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
@@ -1,6 +1,7 @@
 package com.lightinspiration.matrixanimatorapi.services
 
 import com.lightinspiration.matrixanimatorapi.domain.Animation
+import com.lightinspiration.matrixanimatorapi.domain.AnimationMeta
 import com.lightinspiration.matrixanimatorapi.domain.Frame
 import com.lightinspiration.matrixanimatorapi.repositories.AnimationRepository
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -34,7 +35,7 @@ class AnimationServiceTest {
         assertEquals(expected, actual)
     }
 
-    @Test()
+    @Test
     fun `getAnimation - if animation does not exist - throw 404`() {
         val id = 1
         whenever(animationRepository.getAnimation(id))
@@ -46,6 +47,25 @@ class AnimationServiceTest {
     }
 
     @Test
+    fun `getAnimationsList - if animations exist - expect list of animation metadata`() {
+        val animations = listOf(
+            buildAnimation(1, "animation 1"),
+            buildAnimation(2, "animation 2")
+        )
+        whenever(animationRepository.getAnimations())
+            .thenReturn(animations)
+        val expected = listOf(
+            AnimationMeta(1, "animation 1"),
+            AnimationMeta(2, "animation 2")
+        )
+
+        val actual = animationService.getAnimationList()
+
+        assertEquals(expected, actual)
+    }
+
+
+    @Test
     fun `saveAnimation - can save an animation`() {
         val animation = buildAnimation()
 
@@ -55,9 +75,9 @@ class AnimationServiceTest {
     }
 
     companion object {
-        fun buildAnimation(id: Int? = null): Animation {
+        fun buildAnimation(id: Int? = null, title: String? = null): Animation {
             return Animation(
-                "a cool annimation",
+                title ?: "a cool animation",
                 1,
                 8,
                 8,

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
@@ -64,14 +64,23 @@ class AnimationServiceTest {
         assertEquals(expected, actual)
     }
 
-
     @Test
     fun `saveAnimation - can save an animation`() {
         val animation = buildAnimation()
 
         animationService.saveAnimation(animation)
 
-        verify(animationRepository).save(animation)
+        verify(animationRepository).saveAnimation(animation)
+    }
+
+    @Test
+    fun `updateAnimation - can update an animation`() {
+        val id = 10
+        val animation = buildAnimation(id)
+
+        animationService.updateAnimation(id, animation)
+
+        verify(animationRepository).updateAnimation(id, animation)
     }
 
     companion object {

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
@@ -3,12 +3,15 @@ package com.lightinspiration.matrixanimatorapi.services
 import com.lightinspiration.matrixanimatorapi.domain.Animation
 import com.lightinspiration.matrixanimatorapi.domain.Frame
 import com.lightinspiration.matrixanimatorapi.repositories.AnimationRepository
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
 
 @ExtendWith(MockitoExtension::class)
 class AnimationServiceTest {
@@ -20,18 +23,48 @@ class AnimationServiceTest {
     private lateinit var animationService: AnimationService
 
     @Test
+    fun `getAnimation - if animation record exists - can get it by id `() {
+        val id = 1
+        val expected = buildAnimation(id)
+        whenever(animationRepository.getAnimation(id))
+            .thenReturn(expected)
+
+        val actual = animationService.getAnimation(id)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test()
+    fun `getAnimation - if animation does not exist - throw 404`() {
+        val id = 1
+        whenever(animationRepository.getAnimation(id))
+            .thenReturn(null)
+
+        val actual = animationService.getAnimation(id)
+
+        assertEquals(null, actual)
+    }
+
+    @Test
     fun `saveAnimation - can save an animation`() {
-        val animation = Animation(
-            "a cool annimation",
-            1,
-            8,
-            8,
-            1,
-            listOf(Frame(1, listOf(0xFFFFFF, 0xCCCCCC)))
-        )
+        val animation = buildAnimation()
 
         animationService.saveAnimation(animation)
 
         verify(animationRepository).save(animation)
+    }
+
+    companion object {
+        fun buildAnimation(id: Int? = null): Animation {
+            return Animation(
+                "a cool annimation",
+                1,
+                8,
+                8,
+                1,
+                listOf(Frame(1, listOf(0xFFFFFF, 0xCCCCCC))),
+                id
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
@@ -73,6 +73,7 @@ class AnimationServiceTest {
         verify(animationRepository).saveAnimation(animation)
     }
 
+
     @Test
     fun `updateAnimation - can update an animation`() {
         val id = 10
@@ -81,6 +82,15 @@ class AnimationServiceTest {
         animationService.updateAnimation(id, animation)
 
         verify(animationRepository).updateAnimation(id, animation)
+    }
+
+    @Test
+    fun `deleteAnimation - can delete an animation`() {
+        val id = 10
+
+        animationService.deleteAnimation(id)
+
+        verify(animationRepository).deleteAnimation(id)
     }
 
     companion object {

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
@@ -7,6 +7,7 @@ import com.lightinspiration.matrixanimatorapi.domain.Frame
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -74,7 +75,7 @@ class AnimationsWebLayerTest {
 
 
     @Test
-    fun `can save an animation`() {
+    fun `saveAnimation - can save an animation`() {
         val animation = buildAnimation("anAnimation")
         val request = MockMvcRequestBuilders
             .post("/rest/animations")
@@ -86,6 +87,35 @@ class AnimationsWebLayerTest {
 
         verify(animationService).saveAnimation(animation)
     }
+
+    @Test
+    fun `updateAnimation - can update an animation`() {
+        val animation = buildAnimation("anAnimation", 10)
+        val request = MockMvcRequestBuilders
+            .put("/rest/animations")
+            .content(animation.toJson())
+            .contentType(APPLICATION_JSON)
+
+        mockMvc.perform(request)
+            .andExpect(status().isOk)
+
+        verify(animationService).updateAnimation(animation.id!!, animation)
+    }
+
+    @Test
+    fun `updateAnimation - if an animation does not have an id - expect a 422`() {
+        val animation = buildAnimation("anAnimation")
+        val request = MockMvcRequestBuilders
+            .put("/rest/animations")
+            .content(animation.toJson())
+            .contentType(APPLICATION_JSON)
+
+        mockMvc.perform(request)
+            .andExpect(status().isUnprocessableEntity)
+
+        verifyNoMoreInteractions(animationService)
+    }
+
 
     private fun buildAnimation(title: String, id: Int? = null): Animation {
         return Animation(

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
@@ -6,13 +6,14 @@ import com.lightinspiration.matrixanimatorapi.domain.Frame
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(controllers = [AnimationController::class])
@@ -24,12 +25,32 @@ class AnimationsWebLayerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    //TODO: ripout once we have a legit get
     @Test
-    fun `can hit test get endpoint`() {
-        mockMvc.perform(get("/rest/animations/test"))
+    fun `getAnimation - can get an animation`() {
+        val id = 1
+        val expected = Animation("an animation", 1, 8, 8, 2, listOf(Frame(0, listOf(0xFFFFFF))), id)
+        whenever(animationService.getAnimation(id))
+            .thenReturn(expected)
+        val request = MockMvcRequestBuilders
+            .get("/rest/animations/$id")
+
+        mockMvc.perform(request)
             .andExpect(status().isOk)
+            .andExpect(content().json(expected.toJson()))
     }
+
+    @Test
+    fun `getAnimation - if record does not exist - expect 404`() {
+        val id = 1
+        whenever(animationService.getAnimation(id))
+            .thenReturn(null)
+        val request = MockMvcRequestBuilders
+            .get("/rest/animations/$id")
+
+        mockMvc.perform(request)
+            .andExpect(status().isNotFound)
+    }
+
 
     @Test
     fun `can save an animation`() {

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
@@ -117,6 +117,19 @@ class AnimationsWebLayerTest {
     }
 
 
+    @Test
+    fun `deleteAnimation - can delete an existing animation`() {
+        val id = 3
+        val request = MockMvcRequestBuilders
+            .delete("/rest/animations/$id")
+            .contentType(APPLICATION_JSON)
+
+        mockMvc.perform(request)
+            .andExpect(status().isOk)
+
+        verify(animationService).deleteAnimation(3)
+    }
+
     private fun buildAnimation(title: String, id: Int? = null): Animation {
         return Animation(
             title,


### PR DESCRIPTION
With the basic skeleton and temporary test stuff working, I was able to go through and build out the remaining CRUD logic for the API and clean out the temp stuff. 

The logic is basic at the moment, but one of the future PRs is going to introduce the concept of users which will end up modifying some of the simplistic logic here. 