### PR TITLE
Adds initial cors configuration

### DIFF
--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/configuration/CorsConfiguration.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/configuration/CorsConfiguration.kt
@@ -1,0 +1,25 @@
+package com.lightinspiration.matrixanimatorapi.configuration
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfiguration {
+
+    @Bean
+    fun configureCors(@Value("\${cors.allowed-origins}") allowedOrigins: String): WebMvcConfigurer {
+        return object : WebMvcConfigurer {
+            override fun addCorsMappings(registry: CorsRegistry) {
+                registry
+                    .addMapping("/rest/animations/**")
+                    .allowedOrigins(allowedOrigins)
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,10 +5,12 @@ spring:
     schmitz-sandbox:
       # ! Note that the host is `database` which is the name of the database service running
       # ! postgres in docker-compose.yml
-      jdbc-url: jdbc:postgresql://database:5432/postgres
+      jdbc-url: jdbc:postgresql://localhost:5433/postgres
+      #      jdbc-url: jdbc:postgresql://database:5432/postgres
       username: postgres
       password: password # TODO: figure out how to pull this out to .env and inject it on launch. gradle task??
       driver-class-name: org.postgresql.Driver
 
-
+cors:
+  allowed-origins: http://localhost:8081
 


### PR DESCRIPTION
This adds cors so that our front end, that will eventually live as a static site in an s3 bucket, can make calls out to the api. Right now it's just set up for basic local dev, so there'll be another PR in the future to flesh it out more. 