### PR TITLE
Returns the stored animation id when saving

### DIFF
--- a/matrix-animator-api.http
+++ b/matrix-animator-api.http
@@ -4,8 +4,14 @@ Content-Type: application/json
 
 {
   "title": "Test",
-  "frames": []
+  "frames": [],
+  "width": 0,
+  "id": 0,
+  "userId": 0,
+  "speed": 0,
+  "height": 0
 }
+
 
 ### Get an animation by id
 < {%
@@ -34,3 +40,4 @@ Content-Type: application/json
     request.variables.set("id", "38")
 %}
 DELETE http://localhost:8080/rest/animations/{{id}}
+

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
@@ -25,8 +25,8 @@ class AnimationController(
     }
 
     @PostMapping
-    fun saveAnimation(@RequestBody animation: Animation) {
-        animationService.saveAnimation(animation)
+    fun saveAnimation(@RequestBody animation: Animation): Int {
+        return animationService.saveAnimation(animation)
     }
 
     @PutMapping

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service
 class AnimationService(
     val animationRepository: AnimationRepository
 ) {
-    fun saveAnimation(animation: Animation) {
-        animationRepository.saveAnimation(animation)
+    fun saveAnimation(animation: Animation): Int {
+        return animationRepository.saveAnimation(animation)
     }
 
     fun getAnimation(id: Int): Animation? {

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationsControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationsControllerIntegrationTest.kt
@@ -39,17 +39,17 @@ class AnimationsControllerIntegrationTest {
     fun `saveAnimation - can save an animation`() {
         val animation = buildAnimationInstance()
 
-        animationController.saveAnimation(animation)
+        val storedAnimationId = animationController.saveAnimation(animation)
 
         val actual =
-            getAnimationsFromDatabase().first()
+            getAnimationsFromDatabase().first { it.id == storedAnimationId }
                 ?: fail("Got a null when trying to get animation record from the database.")
         assertEquals(animation.title, actual.title)
         assertEquals(animation.height, actual.height)
         assertEquals(animation.width, actual.width)
         assertEquals(animation.speed, actual.speed)
         assertEquals(animation.frames, actual.frames)
-        assert(actual.id != null)
+        assertEquals(storedAnimationId, actual.id)
     }
 
     @Test

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
@@ -48,7 +48,7 @@ class AnimationRepositoryTest {
 
     @Test
     @Transactional
-    fun `saveAnimation - can save animation record successfully`() {
+    fun `saveAnimation - can save animation record successfully with the stored id returned`() {
         val animation = buildAnimation()
 
         val id = animationRepository.saveAnimation(animation)

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
@@ -65,12 +65,15 @@ class AnimationServiceTest {
     }
 
     @Test
-    fun `saveAnimation - can save an animation`() {
+    fun `saveAnimation - can save an animation and return the stored id`() {
         val animation = buildAnimation()
+        val storedAnimationId = 5
+        whenever(animationRepository.saveAnimation(animation))
+            .thenReturn(storedAnimationId)
 
-        animationService.saveAnimation(animation)
+        val actual = animationService.saveAnimation(animation)
 
-        verify(animationRepository).saveAnimation(animation)
+        assertEquals(storedAnimationId, actual)
     }
 
 

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
@@ -76,7 +76,10 @@ class AnimationsWebLayerTest {
 
     @Test
     fun `saveAnimation - can save an animation`() {
+        val storedAnimationId = 3
         val animation = buildAnimation("anAnimation")
+        whenever(animationService.saveAnimation(animation))
+            .thenReturn(storedAnimationId)
         val request = MockMvcRequestBuilders
             .post("/rest/animations")
             .content(animation.toJson())
@@ -84,8 +87,8 @@ class AnimationsWebLayerTest {
 
         mockMvc.perform(request)
             .andExpect(status().isOk)
+            .andExpect(content().string(storedAnimationId.toString()))
 
-        verify(animationService).saveAnimation(animation)
     }
 
     @Test


### PR DESCRIPTION
When testing the API out with the front end client I realized that I need the client to get the stored animation record id back so that subsequent calls can be made to the update endpoint instead of the save endpoint. 

There's part of me that wants to compact the save and update into an upsert, but at the moment I'm not really worried about conflating those two concepts. 