### PR TITLE
Updates update logic to require animation id in url.

### DIFF
--- a/matrix-animator-api.http
+++ b/matrix-animator-api.http
@@ -23,13 +23,15 @@ GET http://localhost:8080/rest/animations/{{id}}
 GET http://localhost:8080/rest/animations
 
 ### Update existing animation
-PUT http://localhost:8080/rest/animations
+< {%
+    request.variables.set("id", "999")
+%}
+PUT http://localhost:8080/rest/animations/{{id}}
 Content-Type: application/json
 
 {
   "title": "Updated animation",
   "frames": [],
-  "id": 34,
   "height": 1,
   "width": 2,
   "speed": 3

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/controllers/AnimationController.kt
@@ -2,6 +2,7 @@ package com.lightinspiration.matrixanimatorapi.controllers
 
 import com.lightinspiration.matrixanimatorapi.domain.Animation
 import com.lightinspiration.matrixanimatorapi.domain.AnimationMeta
+import com.lightinspiration.matrixanimatorapi.repositories.NoRecordToUpdateException
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
@@ -29,12 +30,13 @@ class AnimationController(
         return animationService.saveAnimation(animation)
     }
 
-    @PutMapping
-    fun updateAnimation(@RequestBody animation: Animation) {
-        return if (animation.id != null)
-            animationService.updateAnimation(animation.id, animation)
-        else
+    @PutMapping("/{id}")
+    fun updateAnimation(@PathVariable("id") animationId: Int, @RequestBody animation: Animation): Int {
+        try {
+            return animationService.updateAnimation(animationId, animation)
+        } catch (exception: NoRecordToUpdateException) {
             throw ResponseStatusException(UNPROCESSABLE_ENTITY, "We can't update an animation without it's ID.")
+        }
 
     }
 

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepository.kt
@@ -47,8 +47,9 @@ class AnimationRepository(
         return keyholder.keys?.get("id") as Int
     }
 
-    fun updateAnimation(id: Int, animation: Animation) {
-        template.update(
+    fun updateAnimation(id: Int, animation: Animation): Int {
+        val keyHolder = GeneratedKeyHolder()
+        val affected = template.update(
             """
             UPDATE matrix_animator.animations 
             SET 
@@ -57,8 +58,13 @@ class AnimationRepository(
             (:title, :userId, :height, :width, :speed, :frames::jsonb)
             WHERE id = :id
             """,
-            mapAnimationToParameters(animation).apply { addValue("id", id) }
+            mapAnimationToParameters(animation).apply { addValue("id", id) },
+            keyHolder
         )
+        if (affected == 0) {
+            throw NoRecordToUpdateException("No records were affected by the update.")
+        }
+        return keyHolder.keys?.get("id") as Int
     }
 
     fun deleteAnimation(id: Int): Int {
@@ -102,3 +108,6 @@ class AnimationRepository(
         """
     }
 }
+
+class NoRecordToUpdateException(message: String?) : Exception(message)
+

--- a/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
+++ b/src/main/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationService.kt
@@ -23,8 +23,8 @@ class AnimationService(
             .map { it.metadata() }
     }
 
-    fun updateAnimation(id: Int, animation: Animation) {
-        animationRepository.updateAnimation(id, animation)
+    fun updateAnimation(id: Int, animation: Animation): Int {
+        return animationRepository.updateAnimation(id, animation)
     }
 
     fun deleteAnimation(id: Int) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
     schmitz-sandbox:
       # ! Note that the host is `database` which is the name of the database service running
       # ! postgres in docker-compose.yml
-      jdbc-url: jdbc:postgresql://localhost:5433/postgres
-      #      jdbc-url: jdbc:postgresql://database:5432/postgres
+      #      jdbc-url: jdbc:postgresql://localhost:5433/postgres
+      jdbc-url: jdbc:postgresql://database:5432/postgres
       username: postgres
       password: password # TODO: figure out how to pull this out to .env and inject it on launch. gradle task??
       driver-class-name: org.postgresql.Driver

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/repositories/AnimationRepositoryTest.kt
@@ -65,9 +65,19 @@ class AnimationRepositoryTest {
         val id = insertAnimationRecord(animation)
         val updatedAnimation = Animation("New title", 2, 3, 4, 5, listOf(Frame(0, listOf(0xFFFFFF))))
 
-        animationRepository.updateAnimation(id, updatedAnimation)
+        val actual = animationRepository.updateAnimation(id, updatedAnimation)
 
-        assertEquals(updatedAnimation.copy(id = id), getAnimationRecord(id))
+        assertEquals(id, actual)
+    }
+
+    @Test
+    @Transactional
+    fun `updateAnimation - if record can't be updated - expect exception`() {
+        val updatedAnimation = Animation("New title", 2, 3, 4, 5, listOf(Frame(0, listOf(0xFFFFFF))))
+
+        assertThrows<NoRecordToUpdateException> {
+            animationRepository.updateAnimation(1, updatedAnimation)
+        }
     }
 
 

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/services/AnimationServiceTest.kt
@@ -81,10 +81,11 @@ class AnimationServiceTest {
     fun `updateAnimation - can update an animation`() {
         val id = 10
         val animation = buildAnimation(id)
+        whenever(animationRepository.updateAnimation(id, animation)).thenReturn(id)
 
-        animationService.updateAnimation(id, animation)
+        val actual = animationService.updateAnimation(id, animation)
 
-        verify(animationRepository).updateAnimation(id, animation)
+        assertEquals(id, actual)
     }
 
     @Test

--- a/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
+++ b/src/test/kotlin/com/lightinspiration/matrixanimatorapi/web/AnimationsWebLayerTest.kt
@@ -7,7 +7,6 @@ import com.lightinspiration.matrixanimatorapi.domain.Frame
 import com.lightinspiration.matrixanimatorapi.services.AnimationService
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -93,31 +92,42 @@ class AnimationsWebLayerTest {
 
     @Test
     fun `updateAnimation - can update an animation`() {
-        val animation = buildAnimation("anAnimation", 10)
+        val animationId = 10
+        val animation = buildAnimation("anAnimation", animationId)
+        whenever(animationService.updateAnimation(animation.id!!, animation))
+            .thenReturn(animationId)
         val request = MockMvcRequestBuilders
-            .put("/rest/animations")
+            .put("/rest/animations/${animation.id}")
             .content(animation.toJson())
             .contentType(APPLICATION_JSON)
 
         mockMvc.perform(request)
             .andExpect(status().isOk)
-
-        verify(animationService).updateAnimation(animation.id!!, animation)
+            .andExpect(content().string(animation.id.toString()))
     }
 
-    @Test
-    fun `updateAnimation - if an animation does not have an id - expect a 422`() {
-        val animation = buildAnimation("anAnimation")
-        val request = MockMvcRequestBuilders
-            .put("/rest/animations")
-            .content(animation.toJson())
-            .contentType(APPLICATION_JSON)
-
-        mockMvc.perform(request)
-            .andExpect(status().isUnprocessableEntity)
-
-        verifyNoMoreInteractions(animationService)
-    }
+    //@Test
+    //fun `updateAnimation - if there isn't an animation record to update - expect a 422`() {
+    //    val badId = 9999
+    //    val animation = buildAnimation("anAnimation")
+    // TODO ask andrew about this
+    // * this is the exception that I want to throw, but it's really being thrown at the repository level, which I can't get to from here
+    // * because I'm mocking at the service level. I figured that I could still throw from the mock here to at least assert the conversion from
+    // * the internal exception to the http status exception, but when I do I get an error that the service isn't supposed to raise that checked
+    // * exception.
+    // * at the moment I'm going to put the check in the integration test, which maybe it belongs in anyway, but I figured this would be a good
+    // * place to have all of the http-y stuff. What's his opinion on approach??
+    //    whenever(animationService.updateAnimation(badId, animation)).thenThrow(NoRecordToUpdateException("can't do it"))
+    //    val request = MockMvcRequestBuilders
+    //        .put("/rest/animations/$badId")
+    //        .content(animation.toJson())
+    //        .contentType(APPLICATION_JSON)
+    //
+    //    mockMvc.perform(request)
+    //        .andExpect(status().isUnprocessableEntity)
+    //
+    //    verifyNoMoreInteractions(animationService)
+    //}
 
 
     @Test


### PR DESCRIPTION
While working on the remaining crud of the API I debated on if the animation's ID should be in the animation data class or out on it's own when updating an existing record. At the time I decided to keep it with the DTO and just use the HTTP verb to denote the update vs insert. 

Then I started to dive back into the client side code and realized that I wanted to be more explicit with the ID as part of the request. Either approach is still valid and debatable, but there were two main factors that made me decide to switch direction:

# A natural validation check
The id being required in the URL means that we have a natural validation check for the request's required information.

 i.e. if you don't provide the critical bit of info to do the update (the record id to update) then you can't even successfully make the API call. It also means that we don't have to explicitly interrogate the Animation data class to check to see if the id is missing or not. It's a nullable field in the data class at the moment, so missing the data wouldn't cause an error so you have to explicitly look for it and throw an error. Again, with the ID in the url the check is just part of making the call. 

# Clear code readability for the engineer
The other part that's a bit less critical and a bit more arguable is the readability from the front end. 

![Screenshot 2024-01-01 at 9 05 18 PM](https://github.com/chris-schmitz/matrix-animator-api-2/assets/2437424/d7211f57-09a1-4d78-88ca-6dd9bffab962)

Here we have the helper tooling to make the save vs the update API calls. They're practically identical (which makes sense considering what each is doing), and the big distinguishing characteristics are the http method used, but also the ID standing out visually. 

Really, we could compact the two methods and just programmatically switch based on if the front end has the animation ID or not (and eventually we'll likely do that), but even still I think the ID in the url on the font end forces the engineer to see and think about which one should be used a bit more aside from just the method name. 

--- 

And really all of this could be refactored to just do an upsert on the API side vs explicit save and update, and maybe that's what we should do in the end, but at the moment I'm still feeling like having distinct routes for each. Whateva, we'll see which way the wind is blowing with me in the future ;P

# Fixing a snag: graceful handling of trying to update a record that doesn't exist
A minor fix that's included in this PR is adjusting the update logic to gracefully handle the error that occurs when you try to update an animation that doesn't exist, i.e. you use an ID for a record that doesn't exist in the database. 

I found this snag by accident when testing the code before pushing the commit, so I popped in and changed the ungraceful 500 that gets thrown with a graceful 422 (unprocessable entity) exception. 